### PR TITLE
migrat-postgres: Enable support for SSL connection

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,13 +25,15 @@ var pkg    = require('./package.json');
 module.exports = function(options) {
 	options.port = options.port || 5432;
 	options.host = options.host || 'localhost';
+	options.enableSSL = util.isBoolean(options.enableSSL) ? options.enableSSL : false;
 
-	var connectionString = util.format('postgres://%s:%s@%s:%d/%s',
+	var connectionString = util.format('postgres://%s:%s@%s:%d/%s?ssl=%s',
 		encodeURIComponent(options.user),
 		encodeURIComponent(options.password),
 		options.host,
 		options.port,
-		options.database
+		options.database,
+		options.enableSSL
 	);
 
 	return function(migrat) {


### PR DESCRIPTION
Since current version can not support SSL connection, if user enabled SSL in server side, this plugin will throw an error 'SSL connection is required. Please specify SSL options and retry.'. 